### PR TITLE
Fix start

### DIFF
--- a/src/lib/semanticHelper/SymbolTable.java
+++ b/src/lib/semanticHelper/SymbolTable.java
@@ -364,7 +364,7 @@ public class SymbolTable {
      */
     public Method addMethod(Token token, ArrayList<Param> params, boolean isStatic, Token returnTypeToken, Struct currentStruct) {
         Method result;
-        if (token.getIDToken().equals(IDToken.idSTART)) {
+        if (token.getIDToken().equals(IDToken.idOBJECT) && token.getLexema().equals("start")) {
             //Valida si se está generando el método start y que no se haya generado otro
             if (start == null) {
                 start = new Method(token, params, returnTypeToken, isStatic, 0);

--- a/src/lib/syntaxHelper/First.java
+++ b/src/lib/syntaxHelper/First.java
@@ -18,7 +18,7 @@ public class First {
      * Primeros de Program 
      */
     public static final HashSet<IDToken> firstProgram = new HashSet<IDToken>(){{
-        add(IDToken.idSTART);
+        add(IDToken.idOBJECT); //para start
         add(IDToken.pSTRUCT);
         add(IDToken.pIMPL);
     }};
@@ -26,9 +26,7 @@ public class First {
      * Primeros de Start 
      */
     public static final HashSet<IDToken> firstStart = new HashSet<IDToken>(){{
-        add(IDToken.idSTART);
-        add(IDToken.pSTRUCT);
-        add(IDToken.pIMPL);
+        add(IDToken.idOBJECT); //para start
 
     }};
     /**

--- a/src/lib/tokenHelper/IDToken.java
+++ b/src/lib/tokenHelper/IDToken.java
@@ -76,7 +76,6 @@ public enum IDToken {
     //Identificadores
     /** Para identificadores de estructuras*/ idSTRUCT("id Struct"),
     /** Para identificadores de variables o metodos*/ idOBJECT("id variable o método"),
-    /** Para identificadores de metodo START */ idSTART("start"),
     
 
     //Palabras clave o reservadas

--- a/src/main/LexicalAnalyzer.java
+++ b/src/main/LexicalAnalyzer.java
@@ -572,12 +572,7 @@ public class LexicalAnalyzer {
 
         // No es palabra reservada, entonces es id de Variable o id de Metodo
         if (idToken == null) {
-            // Valida si es el metodo especial start
-            if (currentRead.equals("start")) {
-                idToken = IDToken.idSTART;
-            } else {
-                idToken = IDToken.idOBJECT;
-            }
+            idToken = IDToken.idOBJECT;
         }
     }
 

--- a/src/main/SyntacticAnalyzer.java
+++ b/src/main/SyntacticAnalyzer.java
@@ -172,20 +172,22 @@ public class SyntacticAnalyzer {
     */
     private void start() {
         Token token = currentToken;
-        match(IDToken.idSTART);
-        
-        //Agrega el metodo start
-        semanticManager.addMethod(
-            token, 
-            new ArrayList<Param>(), 
-            false, 
-            new Token(IDToken.typeVOID, "void", token.getLine(), token.getColumn())
-        );
-        
-        bloqueMetodo(token);
-
-        if (!currentToken.getIDToken().equals(IDToken.EOF)){
-            throw throwError(createHashSet(IDToken.EOF));
+        if (currentToken.getLexema().equals("start")){
+            match(IDToken.idOBJECT);
+            
+            //Agrega el metodo start
+            semanticManager.addMethod(
+                token, 
+                new ArrayList<Param>(), 
+                false, 
+                new Token(IDToken.typeVOID, "void", token.getLine(), token.getColumn())
+            );
+            
+            bloqueMetodo(token);
+    
+            if (!currentToken.getIDToken().equals(IDToken.EOF)){
+                throw throwError(createHashSet(IDToken.EOF));
+            }
         }
     }
 

--- a/src/test/resources/profe_test/AST_WHILE01.ast.json
+++ b/src/test/resources/profe_test/AST_WHILE01.ast.json
@@ -69,7 +69,7 @@
                                     "tipo": "SimpleAccess",
                                     "nombreVariable": "1",
                                     "tipoDeDato": "literal Int",
-                                    "resultadoDeTipo": "Int",
+                                    "resultadoDeTipo": "literal Int",
                                     "encadenado": ""
                                 }
                             }

--- a/src/test/resources/profe_test/EXEC_BASICO01.ast.json
+++ b/src/test/resources/profe_test/EXEC_BASICO01.ast.json
@@ -17,7 +17,7 @@
                                 "tipo": "SimpleAccess",
                                 "nombreVariable": "12345",
                                 "tipoDeDato": "literal Int",
-                                "resultadoDeTipo": "Int",
+                                "resultadoDeTipo": "literal Int",
                                 "encadenado": ""
                             }
                         ]

--- a/src/test/resources/profe_test/EXEC_CALLBASICO01.ast.json
+++ b/src/test/resources/profe_test/EXEC_CALLBASICO01.ast.json
@@ -86,14 +86,14 @@
                                 "tipo": "SimpleAccess",
                                 "nombreVariable": "10",
                                 "tipoDeDato": "literal Int",
-                                "resultadoDeTipo": "Int",
+                                "resultadoDeTipo": "literal Int",
                                 "encadenado": ""
                             },
                             {
                                 "tipo": "SimpleAccess",
                                 "nombreVariable": "20",
                                 "tipoDeDato": "literal Int",
-                                "resultadoDeTipo": "Int",
+                                "resultadoDeTipo": "literal Int",
                                 "encadenado": ""
                             }
                         ]

--- a/src/test/resources/profe_test/EXEC_VARINSTBASICO01.ast.json
+++ b/src/test/resources/profe_test/EXEC_VARINSTBASICO01.ast.json
@@ -88,7 +88,7 @@
                                 "tipo": "SimpleAccess",
                                 "nombreVariable": "1234",
                                 "tipoDeDato": "literal Int",
-                                "resultadoDeTipo": "Int",
+                                "resultadoDeTipo": "literal Int",
                                 "encadenado": ""
                             }
                         ]

--- a/src/test/resources/semantic/sentences/correct/TC_START.ast.json
+++ b/src/test/resources/semantic/sentences/correct/TC_START.ast.json
@@ -39,11 +39,50 @@
                         "resultadoDeTipo": "literal Int",
                         "encadenado": ""
                     }
+                },
+                {
+                    "tipo": "Asignation",
+                    "leftSide": {
+                        "tipo": "SimpleAccess",
+                        "nombreVariable": "start",
+                        "tipoDeDato": "id variable o método",
+                        "resultadoDeTipo": "Int",
+                        "encadenado": ""
+                    },
+                    "rightSide": {
+                        "tipo": "SimpleAccess",
+                        "nombreVariable": "10",
+                        "tipoDeDato": "literal Int",
+                        "resultadoDeTipo": "literal Int",
+                        "encadenado": ""
+                    }
                 }
             ]
         }
     ],
     "bloquesDeB" : [
+        {
+            "nombreMetodo": "m1",
+            "sentencias": [
+                {
+                    "tipo": "Asignation",
+                    "leftSide": {
+                        "tipo": "SimpleAccess",
+                        "nombreVariable": "start",
+                        "tipoDeDato": "id variable o método",
+                        "resultadoDeTipo": "Str",
+                        "encadenado": ""
+                    },
+                    "rightSide": {
+                        "tipo": "SimpleAccess",
+                        "nombreVariable": "hola",
+                        "tipoDeDato": "literal Str",
+                        "resultadoDeTipo": "literal Str",
+                        "encadenado": ""
+                    }
+                }
+            ]
+        },
         {
             "nombreMetodo": "Constructor",
             "sentencias": [
@@ -55,7 +94,23 @@
         {
             "nombreMetodo": "start",
             "sentencias": [
-                {}
+                {
+                    "tipo": "Asignation",
+                    "leftSide": {
+                        "tipo": "SimpleAccess",
+                        "nombreVariable": "start",
+                        "tipoDeDato": "id variable o método",
+                        "resultadoDeTipo": "Bool",
+                        "encadenado": ""
+                    },
+                    "rightSide": {
+                        "tipo": "SimpleAccess",
+                        "nombreVariable": "true",
+                        "tipoDeDato": "true",
+                        "resultadoDeTipo": "Bool",
+                        "encadenado": ""
+                    }
+                }
             ]
         }
     ]

--- a/src/test/resources/semantic/sentences/correct/TC_START.ru
+++ b/src/test/resources/semantic/sentences/correct/TC_START.ru
@@ -1,5 +1,6 @@
 struct A{
     B b;
+    Int start;
 }
 
 impl A{
@@ -7,6 +8,7 @@ impl A{
         (nil);
         ("false");
         b.num=1;
+        start=10;
     }
 }
 struct B{
@@ -15,7 +17,12 @@ struct B{
 
 impl B{
     .(){}
+    fn m1(Str start)->void{
+        start="hola";
+    }
 }
 start{
+    Bool start;
+    start=true;
 }
 


### PR DESCRIPTION
se borra IDToken.idSTART para permitir que existan variables, parametros y metodos con id "start"

se modifica firstProgram y firstStart para mantener coherencia (aunque nunca los usamos en el codigo)

Y se modifica el metodo checkLowers() de LexicalAnalyzer para generar al token start con IDToken.idObject