### PR TITLE
Fix start

### DIFF
--- a/src/lib/semanticHelper/SemanticManager.java
+++ b/src/lib/semanticHelper/SemanticManager.java
@@ -88,9 +88,9 @@ public class SemanticManager {
      * @param isStatic Booleano que avisa si es estático o no
      * @param returnTypeToken Tipo de retorno del método
      */
-    public void addMethod(Token token, ArrayList<Param> params, boolean isStatic, Token returnTypeToken) {
+    public void addMethod(Token token, ArrayList<Param> params, boolean isStatic, Token returnTypeToken, Boolean fromStruct) {
         //Agrega el método a la tabla de simbolos
-        currentMethod = symbolTable.addMethod(token, params, isStatic, returnTypeToken, currentStruct);
+        currentMethod = symbolTable.addMethod(token, params, isStatic, returnTypeToken, currentStruct, fromStruct);
     }
 
 
@@ -101,10 +101,10 @@ public class SemanticManager {
      * @param block Bloque de sentencias.
      */
     //METODOS PARA INSERTAR DATOS AL AST
-    public void addBlock(SentenceBlock block){
+    public void addBlock(SentenceBlock block, Boolean fromStruct){
         //Si el bloque método es start, las sentencias no pertenecen a ninguna estructura
         this.ast.addBlock(
-            (!block.getIDBlock().equals("start")) ? currentStruct : null,
+            (! (block.getIDBlock().equals("start") && fromStruct.equals(false)) ? currentStruct : null),
             block
         );
     }

--- a/src/lib/semanticHelper/SymbolTable.java
+++ b/src/lib/semanticHelper/SymbolTable.java
@@ -362,17 +362,12 @@ public class SymbolTable {
      * @param currentStruct Estructura actual a la cual hace referencia
      * @return Method
      */
-    public Method addMethod(Token token, ArrayList<Param> params, boolean isStatic, Token returnTypeToken, Struct currentStruct) {
+    public Method addMethod(Token token, ArrayList<Param> params, boolean isStatic, Token returnTypeToken, Struct currentStruct, Boolean fromStruct) {
         Method result;
-        if (token.getIDToken().equals(IDToken.idOBJECT) && token.getLexema().equals("start")) {
-            //Valida si se está generando el método start y que no se haya generado otro
-            if (start == null) {
-                start = new Method(token, params, returnTypeToken, isStatic, 0);
-                result = start;
-            }
-            else {
-                throw new SemanticException(token, "No se permite definir más de un método start.");
-            }
+        // si fromStruct es false solo puede ser el metodo start principal
+        if (fromStruct.equals(false)) {
+            start = new Method(token, params, returnTypeToken, isStatic, 0);
+            result = start;
         } else {
             // Valida si el tipo de retorno está definido
             if (!returnTypeToken.getIDToken().toString().contains("Array") && !IDToken.typeVOID.equals(returnTypeToken.getIDToken()) && !this.structs.containsKey(returnTypeToken.getLexema())){

--- a/src/lib/semanticHelper/SymbolTable.java
+++ b/src/lib/semanticHelper/SymbolTable.java
@@ -364,7 +364,7 @@ public class SymbolTable {
      */
     public Method addMethod(Token token, ArrayList<Param> params, boolean isStatic, Token returnTypeToken, Struct currentStruct) {
         Method result;
-        if (token.getIDToken().equals(IDToken.idSTART)) {
+        if (token.getIDToken().equals(IDToken.idOBJECT) && token.getLexema().equals("start")) {
             //Valida si se está generando el método start y que no se haya generado otro
             if (start == null) {
                 start = new Method(token, params, returnTypeToken, isStatic, 0);

--- a/src/lib/syntaxHelper/First.java
+++ b/src/lib/syntaxHelper/First.java
@@ -18,7 +18,7 @@ public class First {
      * Primeros de Program 
      */
     public static final HashSet<IDToken> firstProgram = new HashSet<IDToken>(){{
-        add(IDToken.idSTART);
+        add(IDToken.idOBJECT); //para start
         add(IDToken.pSTRUCT);
         add(IDToken.pIMPL);
     }};
@@ -26,9 +26,7 @@ public class First {
      * Primeros de Start 
      */
     public static final HashSet<IDToken> firstStart = new HashSet<IDToken>(){{
-        add(IDToken.idSTART);
-        add(IDToken.pSTRUCT);
-        add(IDToken.pIMPL);
+        add(IDToken.idOBJECT); //para start
 
     }};
     /**

--- a/src/lib/tokenHelper/IDToken.java
+++ b/src/lib/tokenHelper/IDToken.java
@@ -76,7 +76,6 @@ public enum IDToken {
     //Identificadores
     /** Para identificadores de estructuras*/ idSTRUCT("id Struct"),
     /** Para identificadores de variables o metodos*/ idOBJECT("id variable o método"),
-    /** Para identificadores de metodo START */ idSTART("start"),
     
 
     //Palabras clave o reservadas

--- a/src/main/LexicalAnalyzer.java
+++ b/src/main/LexicalAnalyzer.java
@@ -572,12 +572,7 @@ public class LexicalAnalyzer {
 
         // No es palabra reservada, entonces es id de Variable o id de Metodo
         if (idToken == null) {
-            // Valida si es el metodo especial start
-            if (currentRead.equals("start")) {
-                idToken = IDToken.idSTART;
-            } else {
-                idToken = IDToken.idOBJECT;
-            }
+            idToken = IDToken.idOBJECT;
         }
     }
 

--- a/src/main/SyntacticAnalyzer.java
+++ b/src/main/SyntacticAnalyzer.java
@@ -180,10 +180,11 @@ public class SyntacticAnalyzer {
                 token, 
                 new ArrayList<Param>(), 
                 false, 
-                new Token(IDToken.typeVOID, "void", token.getLine(), token.getColumn())
+                new Token(IDToken.typeVOID, "void", token.getLine(), token.getColumn()),
+                false
             );
             
-            bloqueMetodo(token);
+            bloqueMetodo(token,false);
     
             if (!currentToken.getIDToken().equals(IDToken.EOF)){
                 throw throwError(createHashSet(IDToken.EOF));
@@ -304,10 +305,11 @@ public class SyntacticAnalyzer {
         semanticManager.addMethod(
             token, argumentosFormales(), 
             false, 
-            new Token(IDToken.typeVOID, "void", token.getLine(), token.getColumn())
+            new Token(IDToken.typeVOID, "void", token.getLine(), token.getColumn()),
+            true
         );
 
-        bloqueMetodo(token);
+        bloqueMetodo(token,true);
     }
 
 
@@ -352,9 +354,9 @@ public class SyntacticAnalyzer {
         match(IDToken.sARROW_METHOD);
 
         //Agrega el método a la tabla de símbolos
-        semanticManager.addMethod(token, params, isStatic, tipoMetodo());
+        semanticManager.addMethod(token, params, isStatic, tipoMetodo(),true);
 
-        bloqueMetodo(token);
+        bloqueMetodo(token,true);
     }
 
 
@@ -383,7 +385,7 @@ public class SyntacticAnalyzer {
      * 
      * <Bloque-Método> ::= { <Decl-Var-Locales’> <Sentencia’> } | { <Sentencia’> } | { <Decl-Var-Locales’> }  
     */
-    private void bloqueMetodo(Token idBlock) {
+    private void bloqueMetodo(Token idBlock, Boolean fromStruct) {
         //Inicializa el array de sentencias
         ArrayList<Sentence> sentenceList = new ArrayList<Sentence>();
 
@@ -401,7 +403,7 @@ public class SyntacticAnalyzer {
         match(IDToken.sKEY_CLOSE);
 
         //Agrega el bloque (Aunque no posea sentencias)
-        semanticManager.addBlock(new SentenceBlock(idBlock, sentenceList));
+        semanticManager.addBlock(new SentenceBlock(idBlock, sentenceList), fromStruct);
     }
 
 

--- a/src/main/SyntacticAnalyzer.java
+++ b/src/main/SyntacticAnalyzer.java
@@ -172,20 +172,22 @@ public class SyntacticAnalyzer {
     */
     private void start() {
         Token token = currentToken;
-        match(IDToken.idSTART);
-        
-        //Agrega el metodo start
-        semanticManager.addMethod(
-            token, 
-            new ArrayList<Param>(), 
-            false, 
-            new Token(IDToken.typeVOID, "void", token.getLine(), token.getColumn())
-        );
-        
-        bloqueMetodo(token);
-
-        if (!currentToken.getIDToken().equals(IDToken.EOF)){
-            throw throwError(createHashSet(IDToken.EOF));
+        if (currentToken.getLexema().equals("start")){
+            match(IDToken.idOBJECT);
+            
+            //Agrega el metodo start
+            semanticManager.addMethod(
+                token, 
+                new ArrayList<Param>(), 
+                false, 
+                new Token(IDToken.typeVOID, "void", token.getLine(), token.getColumn())
+            );
+            
+            bloqueMetodo(token);
+    
+            if (!currentToken.getIDToken().equals(IDToken.EOF)){
+                throw throwError(createHashSet(IDToken.EOF));
+            }
         }
     }
 

--- a/src/test/resources/profe_test/AST_WHILE01.ast.json
+++ b/src/test/resources/profe_test/AST_WHILE01.ast.json
@@ -69,7 +69,7 @@
                                     "tipo": "SimpleAccess",
                                     "nombreVariable": "1",
                                     "tipoDeDato": "literal Int",
-                                    "resultadoDeTipo": "Int",
+                                    "resultadoDeTipo": "literal Int",
                                     "encadenado": ""
                                 }
                             }

--- a/src/test/resources/profe_test/EXEC_BASICO01.ast.json
+++ b/src/test/resources/profe_test/EXEC_BASICO01.ast.json
@@ -17,7 +17,7 @@
                                 "tipo": "SimpleAccess",
                                 "nombreVariable": "12345",
                                 "tipoDeDato": "literal Int",
-                                "resultadoDeTipo": "Int",
+                                "resultadoDeTipo": "literal Int",
                                 "encadenado": ""
                             }
                         ]

--- a/src/test/resources/profe_test/EXEC_CALLBASICO01.ast.json
+++ b/src/test/resources/profe_test/EXEC_CALLBASICO01.ast.json
@@ -86,14 +86,14 @@
                                 "tipo": "SimpleAccess",
                                 "nombreVariable": "10",
                                 "tipoDeDato": "literal Int",
-                                "resultadoDeTipo": "Int",
+                                "resultadoDeTipo": "literal Int",
                                 "encadenado": ""
                             },
                             {
                                 "tipo": "SimpleAccess",
                                 "nombreVariable": "20",
                                 "tipoDeDato": "literal Int",
-                                "resultadoDeTipo": "Int",
+                                "resultadoDeTipo": "literal Int",
                                 "encadenado": ""
                             }
                         ]

--- a/src/test/resources/profe_test/EXEC_VARINSTBASICO01.ast.json
+++ b/src/test/resources/profe_test/EXEC_VARINSTBASICO01.ast.json
@@ -88,7 +88,7 @@
                                 "tipo": "SimpleAccess",
                                 "nombreVariable": "1234",
                                 "tipoDeDato": "literal Int",
-                                "resultadoDeTipo": "Int",
+                                "resultadoDeTipo": "literal Int",
                                 "encadenado": ""
                             }
                         ]

--- a/src/test/resources/semantic/error/TC_ERROR_START.ru
+++ b/src/test/resources/semantic/error/TC_ERROR_START.ru
@@ -1,0 +1,13 @@
+struct A{
+
+}
+impl A{
+    .(){}
+}
+
+start{
+
+}
+start{
+    
+}

--- a/src/test/resources/semantic/sentences/correct/TC_START.ast.json
+++ b/src/test/resources/semantic/sentences/correct/TC_START.ast.json
@@ -39,11 +39,50 @@
                         "resultadoDeTipo": "literal Int",
                         "encadenado": ""
                     }
+                },
+                {
+                    "tipo": "Asignation",
+                    "leftSide": {
+                        "tipo": "SimpleAccess",
+                        "nombreVariable": "start",
+                        "tipoDeDato": "id variable o método",
+                        "resultadoDeTipo": "Int",
+                        "encadenado": ""
+                    },
+                    "rightSide": {
+                        "tipo": "SimpleAccess",
+                        "nombreVariable": "10",
+                        "tipoDeDato": "literal Int",
+                        "resultadoDeTipo": "literal Int",
+                        "encadenado": ""
+                    }
                 }
             ]
         }
     ],
     "bloquesDeB" : [
+        {
+            "nombreMetodo": "m1",
+            "sentencias": [
+                {
+                    "tipo": "Asignation",
+                    "leftSide": {
+                        "tipo": "SimpleAccess",
+                        "nombreVariable": "start",
+                        "tipoDeDato": "id variable o método",
+                        "resultadoDeTipo": "Str",
+                        "encadenado": ""
+                    },
+                    "rightSide": {
+                        "tipo": "SimpleAccess",
+                        "nombreVariable": "hola",
+                        "tipoDeDato": "literal Str",
+                        "resultadoDeTipo": "literal Str",
+                        "encadenado": ""
+                    }
+                }
+            ]
+        },
         {
             "nombreMetodo": "Constructor",
             "sentencias": [
@@ -55,7 +94,23 @@
         {
             "nombreMetodo": "start",
             "sentencias": [
-                {}
+                {
+                    "tipo": "Asignation",
+                    "leftSide": {
+                        "tipo": "SimpleAccess",
+                        "nombreVariable": "start",
+                        "tipoDeDato": "id variable o método",
+                        "resultadoDeTipo": "Bool",
+                        "encadenado": ""
+                    },
+                    "rightSide": {
+                        "tipo": "SimpleAccess",
+                        "nombreVariable": "true",
+                        "tipoDeDato": "true",
+                        "resultadoDeTipo": "Bool",
+                        "encadenado": ""
+                    }
+                }
             ]
         }
     ]

--- a/src/test/resources/semantic/sentences/correct/TC_START.ast.json
+++ b/src/test/resources/semantic/sentences/correct/TC_START.ast.json
@@ -68,6 +68,34 @@
                     "tipo": "Asignation",
                     "leftSide": {
                         "tipo": "SimpleAccess",
+                        "nombreVariable": "m1",
+                        "tipoDeDato": "id variable o método",
+                        "resultadoDeTipo": "Int",
+                        "encadenado": ""
+                    },
+                    "rightSide": {
+                        "tipo": "SimpleAccess",
+                        "nombreVariable": "1",
+                        "tipoDeDato": "literal Int",
+                        "resultadoDeTipo": "literal Int",
+                        "encadenado": ""
+                    }
+                }
+            ]
+        },
+        {
+            "nombreMetodo": "Constructor",
+            "sentencias": [
+                {}
+            ]
+        },
+        {
+            "nombreMetodo": "start",
+            "sentencias": [
+                {
+                    "tipo": "Asignation",
+                    "leftSide": {
+                        "tipo": "SimpleAccess",
                         "nombreVariable": "start",
                         "tipoDeDato": "id variable o método",
                         "resultadoDeTipo": "Str",
@@ -80,13 +108,17 @@
                         "resultadoDeTipo": "literal Str",
                         "encadenado": ""
                     }
+                },
+                {
+                    "tipo": "Return",
+                    "expresión": {
+                        "tipo": "SimpleAccess",
+                        "nombreVariable": "1",
+                        "tipoDeDato": "literal Int",
+                        "resultadoDeTipo": "literal Int",
+                        "encadenado": ""
+                    }
                 }
-            ]
-        },
-        {
-            "nombreMetodo": "Constructor",
-            "sentencias": [
-                {}
             ]
         }
     ],

--- a/src/test/resources/semantic/sentences/correct/TC_START.ru
+++ b/src/test/resources/semantic/sentences/correct/TC_START.ru
@@ -1,5 +1,6 @@
 struct A{
     B b;
+    Int start;
 }
 
 impl A{
@@ -7,6 +8,7 @@ impl A{
         (nil);
         ("false");
         b.num=1;
+        start=10;
     }
 }
 struct B{
@@ -15,7 +17,12 @@ struct B{
 
 impl B{
     .(){}
+    fn m1(Str start)->void{
+        start="hola";
+    }
 }
 start{
+    Bool start;
+    start=true;
 }
 

--- a/src/test/resources/semantic/sentences/correct/TC_START.ru
+++ b/src/test/resources/semantic/sentences/correct/TC_START.ru
@@ -17,12 +17,15 @@ struct B{
 
 impl B{
     .(){}
-    fn m1(Str start)->void{
+    fn start(Str start)->Int{
         start="hola";
+        ret 1;
+    }
+    fn m1(Int m1)->void{
+        m1=1;
     }
 }
 start{
     Bool start;
     start=true;
 }
-

--- a/src/test/resources/semantic/sentences/correct/TC_START.ts.json
+++ b/src/test/resources/semantic/sentences/correct/TC_START.ts.json
@@ -1,0 +1,398 @@
+{
+    "structs": [
+        {
+            "nombre": "Str",
+            "heredaDe": "Object",
+            "constructor": [],
+            "cantidadMetodos": 2,
+            "cantidadAtributos": 0,
+            "atributos": [],
+            "métodos": [
+                {
+                    "nombre": "length",
+                    "static": "false",
+                    "retorno": "Int",
+                    "posicion": 0,
+                    "parámetros": [],
+                    "variables": []
+                },
+                {
+                    "nombre": "concat",
+                    "static": "false",
+                    "retorno": "Str",
+                    "posicion": 1,
+                    "parámetros": [
+                        {
+                            "nombre": "s",
+                            "tipo": "Str",
+                            "posicion": 0
+                        }
+                    ],
+                    "variables": []
+                }
+            ]
+        },
+        {
+            "nombre": "Array Str",
+            "heredaDe": "Object",
+            "constructor": [],
+            "cantidadMetodos": 1,
+            "cantidadAtributos": 0,
+            "atributos": [],
+            "métodos": [
+                {
+                    "nombre": "length",
+                    "static": "false",
+                    "retorno": "Int",
+                    "posicion": 0,
+                    "parámetros": [],
+                    "variables": []
+                }
+            ]
+        },
+        {
+            "nombre": "A",
+            "heredaDe": "Object",
+            "constructor": [
+                {
+                    "nombre": ".",
+                    "static": "false",
+                    "retorno": "void",
+                    "posicion": 0,
+                    "parámetros": [],
+                    "variables": []
+                }            
+            ],
+            "cantidadMetodos": 0,
+            "cantidadAtributos": 2,
+            "atributos": [
+                {
+                    "nombre": "b",
+                    "tipo": "B",
+                    "public": "true",
+                    "posicion": 0
+                },
+                {
+                    "nombre": "start",
+                    "tipo": "Int",
+                    "public": "true",
+                    "posicion": 1
+                }
+            ],
+            "métodos": []
+        },
+        {
+            "nombre": "B",
+            "heredaDe": "Object",
+            "constructor": [
+                {
+                    "nombre": ".",
+                    "static": "false",
+                    "retorno": "void",
+                    "posicion": 0,
+                    "parámetros": [],
+                    "variables": []
+                }            
+            ],
+            "cantidadMetodos": 2,
+            "cantidadAtributos": 1,
+            "atributos": [
+                {
+                    "nombre": "num",
+                    "tipo": "Int",
+                    "public": "true",
+                    "posicion": 0
+                }
+            ],
+            "métodos": [
+                {
+                    "nombre": "start",
+                    "static": "false",
+                    "retorno": "Int",
+                    "posicion": 0,
+                    "parámetros": [
+                        {
+                            "nombre": "start",
+                            "tipo": "Str",
+                            "posicion": 0
+                        }
+                    ],
+                    "variables": []
+                },
+                {
+                    "nombre": "m1",
+                    "static": "false",
+                    "retorno": "void",
+                    "posicion": 1,
+                    "parámetros": [
+                        {
+                            "nombre": "m1",
+                            "tipo": "Int",
+                            "posicion": 0
+                        }
+                    ],
+                    "variables": []
+                }
+            ]
+        },
+        {
+            "nombre": "Array Int",
+            "heredaDe": "Object",
+            "constructor": [],
+            "cantidadMetodos": 1,
+            "cantidadAtributos": 0,
+            "atributos": [],
+            "métodos": [
+                {
+                    "nombre": "length",
+                    "static": "false",
+                    "retorno": "Int",
+                    "posicion": 0,
+                    "parámetros": [],
+                    "variables": []
+                }
+            ]
+        },
+        {
+            "nombre": "Array Char",
+            "heredaDe": "Object",
+            "constructor": [],
+            "cantidadMetodos": 1,
+            "cantidadAtributos": 0,
+            "atributos": [],
+            "métodos": [
+                {
+                    "nombre": "length",
+                    "static": "false",
+                    "retorno": "void",
+                    "posicion": 0,
+                    "parámetros": [],
+                    "variables": []
+                }
+            ]
+        },
+        {
+            "nombre": "Bool",
+            "heredaDe": "Object",
+            "constructor": [],
+            "cantidadMetodos": 0,
+            "cantidadAtributos": 0,
+            "atributos": [],
+            "métodos": []
+        },
+        {
+            "nombre": "IO",
+            "heredaDe": "Object",
+            "constructor": [],
+            "cantidadMetodos": 12,
+            "cantidadAtributos": 0,
+            "atributos": [],
+            "métodos": [
+                {
+                    "nombre": "out_array_int",
+                    "static": "true",
+                    "retorno": "void",
+                    "posicion": 0,
+                    "parámetros": [
+                        {
+                            "nombre": "a",
+                            "tipo": "Array",
+                            "posicion": 0
+                        }
+                    ],
+                    "variables": []
+                },
+                {
+                    "nombre": "out_array_char",
+                    "static": "true",
+                    "retorno": "void",
+                    "posicion": 1,
+                    "parámetros": [
+                        {
+                            "nombre": "a",
+                            "tipo": "Array",
+                            "posicion": 0
+                        }
+                    ],
+                    "variables": []
+                },
+                {
+                    "nombre": "in_str",
+                    "static": "true",
+                    "retorno": "Str",
+                    "posicion": 2,
+                    "parámetros": [],
+                    "variables": []
+                },
+                {
+                    "nombre": "out_char",
+                    "static": "true",
+                    "retorno": "void",
+                    "posicion": 3,
+                    "parámetros": [
+                        {
+                            "nombre": "c",
+                            "tipo": "Char",
+                            "posicion": 0
+                        }
+                    ],
+                    "variables": []
+                },
+                {
+                    "nombre": "out_array_str",
+                    "static": "true",
+                    "retorno": "void",
+                    "posicion": 4,
+                    "parámetros": [
+                        {
+                            "nombre": "a",
+                            "tipo": "Array",
+                            "posicion": 0
+                        }
+                    ],
+                    "variables": []
+                },
+                {
+                    "nombre": "in_int",
+                    "static": "true",
+                    "retorno": "Int",
+                    "posicion": 5,
+                    "parámetros": [],
+                    "variables": []
+                },
+                {
+                    "nombre": "out_int",
+                    "static": "true",
+                    "retorno": "void",
+                    "posicion": 6,
+                    "parámetros": [
+                        {
+                            "nombre": "i",
+                            "tipo": "Int",
+                            "posicion": 0
+                        }
+                    ],
+                    "variables": []
+                },
+                {
+                    "nombre": "in_bool",
+                    "static": "true",
+                    "retorno": "Bool",
+                    "posicion": 7,
+                    "parámetros": [],
+                    "variables": []
+                },
+                {
+                    "nombre": "out_str",
+                    "static": "true",
+                    "retorno": "void",
+                    "posicion": 8,
+                    "parámetros": [
+                        {
+                            "nombre": "s",
+                            "tipo": "Str",
+                            "posicion": 0
+                        }
+                    ],
+                    "variables": []
+                },
+                {
+                    "nombre": "in_char",
+                    "static": "true",
+                    "retorno": "Char",
+                    "posicion": 9,
+                    "parámetros": [],
+                    "variables": []
+                },
+                {
+                    "nombre": "out_bool",
+                    "static": "true",
+                    "retorno": "void",
+                    "posicion": 10,
+                    "parámetros": [
+                        {
+                            "nombre": "b",
+                            "tipo": "Bool",
+                            "posicion": 0
+                        }
+                    ],
+                    "variables": []
+                },
+                {
+                    "nombre": "out_array_bool",
+                    "static": "true",
+                    "retorno": "void",
+                    "posicion": 11,
+                    "parámetros": [
+                        {
+                            "nombre": "a",
+                            "tipo": "Array",
+                            "posicion": 0
+                        }
+                    ],
+                    "variables": []
+                }
+            ]
+        },
+        {
+            "nombre": "Char",
+            "heredaDe": "Object",
+            "constructor": [],
+            "cantidadMetodos": 0,
+            "cantidadAtributos": 0,
+            "atributos": [],
+            "métodos": []
+        },
+        {
+            "nombre": "Object",
+            "heredaDe": "No posee",
+            "constructor": [],
+            "cantidadMetodos": 0,
+            "cantidadAtributos": 0,
+            "atributos": [],
+            "métodos": []
+        },
+        {
+            "nombre": "Int",
+            "heredaDe": "Object",
+            "constructor": [],
+            "cantidadMetodos": 0,
+            "cantidadAtributos": 0,
+            "atributos": [],
+            "métodos": []
+        },
+        {
+            "nombre": "Array Bool",
+            "heredaDe": "Object",
+            "constructor": [],
+            "cantidadMetodos": 1,
+            "cantidadAtributos": 0,
+            "atributos": [],
+            "métodos": [
+                {
+                    "nombre": "length",
+                    "static": "false",
+                    "retorno": "Int",
+                    "posicion": 0,
+                    "parámetros": [],
+                    "variables": []
+                }
+            ]
+        }
+    ],
+    "start": {
+        "nombre": "start",
+        "static": "false",
+        "retorno": "void",
+        "posicion": 0,
+        "parámetros": [],
+        "variables": [
+            {
+                "nombre": "start",
+                "tipo": "Bool",
+                "public": "false",
+                "posicion": 0
+            }
+        ]
+    }
+}


### PR DESCRIPTION
se borra IDToken.idSTART para permitir que existan variables, parametros y metodos con id "start"

se modifica firstProgram y firstStart para mantener coherencia (aunque nunca los usamos en el codigo)

se modifica el metodo checkLowers() de LexicalAnalyzer para generar al token start con IDToken.idObject

y se pasa un boolean a semanticManager.addBlock() para controlar si un metodo start es de un struct o no.  